### PR TITLE
Fix `zap.Simple*` structs being undefined.

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const zap = @import("zap");
 
-fn on_request_verbose(r: zap.SimpleRequest) void {
+fn on_request_verbose(r: zap.Request) void {
     if (r.path) |the_path| {
         std.debug.print("PATH: {s}\n", .{the_path});
     }
@@ -12,12 +12,12 @@ fn on_request_verbose(r: zap.SimpleRequest) void {
     r.sendBody("<html><body><h1>Hello from ZAP!!!</h1></body></html>") catch return;
 }
 
-fn on_request_minimal(r: zap.SimpleRequest) void {
+fn on_request_minimal(r: zap.Request) void {
     r.sendBody("<html><body><h1>Hello from ZAP!!!</h1></body></html>") catch return;
 }
 
 pub fn main() !void {
-    var listener = zap.SimpleHttpListener.init(.{
+    var listener = zap.HttpListener.init(.{
         .port = 3000,
         .on_request = on_request_verbose,
         .log = true,


### PR DESCRIPTION
The API seems to have changed on the `zap-0.12.0` branch such that the `Simple` prefix was removed from multiple struct names.